### PR TITLE
Check OTAU slot and battery before starting

### DIFF
--- a/persistences/src/main/kotlin/fr/velco/otau/persistences/velco/dao/OtauTrackingDao.kt
+++ b/persistences/src/main/kotlin/fr/velco/otau/persistences/velco/dao/OtauTrackingDao.kt
@@ -3,8 +3,13 @@ package fr.velco.otau.persistences.velco.dao
 import fr.velco.otau.persistences.velco.table.OtauTracking
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
 
 @Repository
 interface OtauTrackingDao : JpaRepository<OtauTracking, Long> {
     fun findFirstByIdProduct(idProduct: Long): OtauTracking?
+
+    fun countByLastUpdateAfter(lastUpdate: LocalDateTime): Int
+
+    fun findByLastUpdateBefore(lastUpdate: LocalDateTime): List<OtauTracking>
 }

--- a/services/src/main/kotlin/fr/velco/otau/services/dto/ProductDto.kt
+++ b/services/src/main/kotlin/fr/velco/otau/services/dto/ProductDto.kt
@@ -7,6 +7,7 @@ class ProductDto(
     val aesKey: ByteArray,
     val serialNumber: String,
     val idFirmware: Long?,
+    val batteryLevel: Short?,
 ) {
     companion object {
         fun fromEntity(product: Product) = ProductDto(
@@ -14,6 +15,7 @@ class ProductDto(
             aesKey = product.aesKey ?: throw Exception("This product has no aesKey"),
             serialNumber = product.serialNumber,
             idFirmware = product.idNuotraxFirmwareAvailable,
+            batteryLevel = product.batteryLevel,
         )
     }
 }

--- a/services/src/main/kotlin/fr/velco/otau/services/service/DataType0NuotraxVersionService.kt
+++ b/services/src/main/kotlin/fr/velco/otau/services/service/DataType0NuotraxVersionService.kt
@@ -80,6 +80,15 @@ class DataType0NuotraxVersionService(
         //First, we request the IoT to check his state
         //Either he is ready for a new OTAU: it will answer 2:DFU Packet Data ID/IDLE #0
         //Either he is already in OTAU mode: it will answer 2:DFU Packet Data ID/DFU_RX #n
+
+        if (!this.dataTypeService.isBatteryLevelSufficient(product.batteryLevel, logCtx)) {
+            return
+        }
+
+        if (!this.otauTrackingService.isOtauSlotAvailable(logCtx)) {
+            return
+        }
+
         this.dfuDataTopicService.sendAskForLastPacketId(productDto, logCtx)
     }
 

--- a/services/src/main/kotlin/fr/velco/otau/services/service/DataTypeService.kt
+++ b/services/src/main/kotlin/fr/velco/otau/services/service/DataTypeService.kt
@@ -91,6 +91,19 @@ class DataTypeService(
         return false
     }
 
+    /**
+     * Check if the IoT battery level is sufficient for an OTAU.
+     * The battery level is added into the log context.
+     */
+    fun isBatteryLevelSufficient(batteryLevel: Short?, logCtx: MutableMap<String, String>): Boolean {
+        logCtx += mapOf("batteryLevel" to (batteryLevel?.toString() ?: "null"))
+        if (batteryLevel == null || batteryLevel < properties.minBatteryLvlOtau) {
+            log.info("IoT battery level is too low", logCtx)
+            return false
+        }
+        return true
+    }
+
     fun sendPacket(productDto: ProductDto, packetNumber: Int, logCtx: MutableMap<String, String>, logWithoutModulo: Boolean = false) {
         if (logWithoutModulo || ((packetNumber % properties.logModulo) == 0)) log.info("Send packet", logCtx)
 

--- a/services/src/main/kotlin/fr/velco/otau/services/service/TriggerService.kt
+++ b/services/src/main/kotlin/fr/velco/otau/services/service/TriggerService.kt
@@ -1,13 +1,11 @@
 package fr.velco.otau.services.service
 
 import fr.velco.back.framework.logging.VelcoLogger
-import fr.velco.otau.services.config.Properties
 import fr.velco.otau.services.service.cache.ProductCacheService
 import org.springframework.stereotype.Service
 
 @Service
 class TriggerService(
-    private val properties: Properties,
     private val productCacheService: ProductCacheService,
     private val otauTrackingService: OtauTrackingService,
     private val dfuDataTopicService: DfuDataTopicService,
@@ -23,13 +21,9 @@ class TriggerService(
 
         val productDto = productCacheService.getProduct(serialNumber)
         if (productDto.idFirmware != null) { //is OTAU scheduled?
-            val numberOfActiveOtau = otauTrackingService.cleanupAndReturnNumberOfActiveOtau()
-            logCtx += mapOf("numberOfActiveOtau" to numberOfActiveOtau.toString())
-            if (numberOfActiveOtau < properties.maxSimultaneousOtau) { //slot available?
+            if (otauTrackingService.isOtauSlotAvailable(logCtx)) {
                 log.info("Max active OTAU not reached. Try to launch a new one", logCtx)
                 dfuDataTopicService.sendAskNuotraxVersion(productDto, logCtx)
-            } else {
-                log.info("Max active OTAU reached", logCtx)
             }
         }
     }

--- a/services/src/test/kotlin/fr/velco/otau/services/DataSet.kt
+++ b/services/src/test/kotlin/fr/velco/otau/services/DataSet.kt
@@ -15,11 +15,12 @@ open class DataSet {
         idNuotraxFirmwareAvailable = idFirmware,
     )
 
-    protected fun getProductDto(idFirmware: Long? = null) = ProductDto(
+    protected fun getProductDto(idFirmware: Long? = null, batteryLevel: Short? = 75) = ProductDto(
         id = 0,
         serialNumber = "N12345",
         aesKey = HexStringUtils.fromHexString("6960472942B621D29623EC7E06141556"),
         idFirmware = idFirmware,
+        batteryLevel = batteryLevel,
     )
 
     protected fun getFirmware() = FirmwareDto(

--- a/services/src/test/kotlin/fr/velco/otau/services/DataType0NuotraxVersionServiceTest.kt
+++ b/services/src/test/kotlin/fr/velco/otau/services/DataType0NuotraxVersionServiceTest.kt
@@ -97,7 +97,9 @@ class DataType0NuotraxVersionServiceTest : KotlinMockitoHelper() {
         val productDtoBefore = getProductDto(idFirmware = 1)
         `when`(firmwareCacheService.getFirmware(productDtoBefore.idFirmware ?: 0)).thenReturn(getFirmware())
         `when`(dataTypeService.isEligibleToATargetVersion(any(ProductDto::class.java), anyMap())).thenReturn(true)
+        `when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(true)
         `when`(productDao.getReferenceById(0)).thenReturn(getProduct(idFirmware = 1))
+        `when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
 
         //Act
         dataType0NuotraxVersionService.treat(productDtoBefore, payload)
@@ -134,7 +136,9 @@ class DataType0NuotraxVersionServiceTest : KotlinMockitoHelper() {
         val productDtoBefore = getProductDto(idFirmware = 1)
         `when`(firmwareCacheService.getFirmware(productDtoBefore.idFirmware ?: 0)).thenReturn(getFirmware())
         `when`(dataTypeService.isEligibleToATargetVersion(any(ProductDto::class.java), anyMap())).thenReturn(true)
+        `when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(true)
         `when`(productDao.getReferenceById(0)).thenReturn(getProduct(idFirmware = 1))
+        `when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
 
         //Act
         dataType0NuotraxVersionService.treat(productDtoBefore, payload)
@@ -143,10 +147,67 @@ class DataType0NuotraxVersionServiceTest : KotlinMockitoHelper() {
         val productCaptor: ArgumentCaptor<Product> = ArgumentCaptor.forClass(Product::class.java)
         Mockito.verify(productDao, Mockito.times(1)).save(capture(productCaptor))
         Mockito.verify(dfuDataTopicService, Mockito.times(1)).sendAskForLastPacketId(any(ProductDto::class.java), anyMap()) //principal assert of this test
+        Mockito.verify(otauTrackingService, Mockito.times(1)).isOtauSlotAvailable(anyMap())
 
         val productAfter: Product = productCaptor.value
         assertEquals("1.2.3.3", productAfter.nuotraxFirmwareVersion)
         assertEquals("4.3.2.1", productAfter.bootloaderVersion)
+    }
+
+    @Test
+    fun `threat() with IoT eligible not up-to-date but without slot should not start an OTAU`() {
+        //Arrange
+        val payload = byteArrayOf(
+            0x00, //Nuotrax Version
+            0x01, //Firmware Version
+            0x02,
+            0x03,
+            0x03,
+            0x04, //BootLoader Version
+            0x03,
+            0x02,
+            0x01,
+        )
+        val productDtoBefore = getProductDto(idFirmware = 1)
+        `when`(firmwareCacheService.getFirmware(productDtoBefore.idFirmware ?: 0)).thenReturn(getFirmware())
+        `when`(dataTypeService.isEligibleToATargetVersion(any(ProductDto::class.java), anyMap())).thenReturn(true)
+        `when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(true)
+        `when`(productDao.getReferenceById(0)).thenReturn(getProduct(idFirmware = 1))
+        `when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(false)
+
+        //Act
+        dataType0NuotraxVersionService.treat(productDtoBefore, payload)
+
+        //Assert
+        Mockito.verify(dfuDataTopicService, Mockito.times(0)).sendAskForLastPacketId(any(ProductDto::class.java), anyMap())
+
+    }
+
+    @Test
+    fun `threat() with IoT eligible not up-to-date but battery too low should not start an OTAU`() {
+        //Arrange
+        val payload = byteArrayOf(
+            0x00, //Nuotrax Version
+            0x01, //Firmware Version
+            0x02,
+            0x03,
+            0x03,
+            0x04, //BootLoader Version
+            0x03,
+            0x02,
+            0x01,
+        )
+        val productDtoBefore = getProductDto(idFirmware = 1)
+        `when`(firmwareCacheService.getFirmware(productDtoBefore.idFirmware ?: 0)).thenReturn(getFirmware())
+        `when`(dataTypeService.isEligibleToATargetVersion(any(ProductDto::class.java), anyMap())).thenReturn(true)
+        `when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(false)
+        `when`(productDao.getReferenceById(0)).thenReturn(getProduct(idFirmware = 1))
+
+        //Act
+        dataType0NuotraxVersionService.treat(productDtoBefore, payload)
+
+        //Assert
+        Mockito.verify(dfuDataTopicService, Mockito.times(0)).sendAskForLastPacketId(any(ProductDto::class.java), anyMap())
     }
 
     @Test

--- a/services/src/test/kotlin/fr/velco/otau/services/DataType2DfuReadyStatusDfuRxServiceTest.kt
+++ b/services/src/test/kotlin/fr/velco/otau/services/DataType2DfuReadyStatusDfuRxServiceTest.kt
@@ -47,6 +47,7 @@ class DataType2DfuReadyStatusDfuRxServiceTest : KotlinMockitoHelper() {
             0x02, //Process step DFU_RX
         )
         val productDto = getProductDto()
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
         Mockito.`when`(dataTypeService.getOtauTrackingOrSendEndOfTransmission(any(ProductDto::class.java), anyMap())).thenReturn(getOtauTracking())
 
         //Act
@@ -68,6 +69,7 @@ class DataType2DfuReadyStatusDfuRxServiceTest : KotlinMockitoHelper() {
             0x02, //Process step DFU_RX
         )
         val productDto = getProductDto()
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
         Mockito.`when`(dataTypeService.getOtauTrackingOrSendEndOfTransmission(any(ProductDto::class.java), anyMap())).thenReturn(getOtauTracking())
         Mockito.`when`(dataTypeService.isLastPacket(any(ProductDto::class.java), eq(2), anyMap())).thenReturn(false)
 
@@ -91,6 +93,7 @@ class DataType2DfuReadyStatusDfuRxServiceTest : KotlinMockitoHelper() {
             0x02, //Process step DFU_RX
         )
         val productDto = getProductDto()
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
         Mockito.`when`(dataTypeService.getOtauTrackingOrSendEndOfTransmission(any(ProductDto::class.java), anyMap())).thenReturn(getOtauTracking())
         Mockito.`when`(dataTypeService.isLastPacket(any(ProductDto::class.java), eq(3), anyMap())).thenReturn(false)
 
@@ -114,6 +117,7 @@ class DataType2DfuReadyStatusDfuRxServiceTest : KotlinMockitoHelper() {
             0x02, //Process step DFU_RX
         )
         val productDto = getProductDto()
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
         Mockito.`when`(dataTypeService.getOtauTrackingOrSendEndOfTransmission(any(ProductDto::class.java), anyMap())).thenReturn(getOtauTracking())
         Mockito.`when`(dataTypeService.isLastPacket(any(ProductDto::class.java), eq(2), anyMap())).thenReturn(true)
 
@@ -125,5 +129,28 @@ class DataType2DfuReadyStatusDfuRxServiceTest : KotlinMockitoHelper() {
         Mockito.verify(otauTrackingService, Mockito.times(1)).setLastPacketAcked(any(ProductDto::class.java), eq(2), anyMap())
         Mockito.verify(dfuDataTopicService, Mockito.times(1)).sendEndOfTransmission(any(ProductDto::class.java), anyMap())
         Mockito.verify(dataTypeService, Mockito.times(0)).sendPacket(any(ProductDto::class.java), anyInt(), anyMap(), eq(true))
+    }
+
+    @Test
+    fun `threat() DFU_RX without slot should not continue`() {
+        //Arrange
+        val payload = byteArrayOf(
+            0x02, //DFU Packet Data ID
+            0x00, //Last Packet Number ID #2
+            0x02,
+            0x02, //Process step DFU_RX
+        )
+        val productDto = getProductDto()
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(false)
+
+        //Act
+        dataType2DfuPacketDataIdService.treat(productDto, payload)
+
+        //Assert
+        Mockito.verify(dataTypeService, Mockito.times(1)).sendEndOfTransmissionIfNotEligibleToATargetVersion(any(ProductDto::class.java), anyMap())
+        Mockito.verify(dataTypeService, Mockito.times(0)).getOtauTrackingOrSendEndOfTransmission(any(ProductDto::class.java), anyMap())
+        Mockito.verify(otauTrackingService, Mockito.times(1)).isOtauSlotAvailable(anyMap())
+        Mockito.verify(otauTrackingService, Mockito.times(0)).setLastPacketAcked(any(ProductDto::class.java), anyInt(), anyMap())
+        Mockito.verify(dataTypeService, Mockito.times(0)).sendPacket(any(ProductDto::class.java), anyInt(), anyMap(), anyBoolean())
     }
 }

--- a/services/src/test/kotlin/fr/velco/otau/services/DataType2DfuReadyStatusIdleServiceTest.kt
+++ b/services/src/test/kotlin/fr/velco/otau/services/DataType2DfuReadyStatusIdleServiceTest.kt
@@ -60,6 +60,8 @@ class DataType2DfuReadyStatusIdleServiceTest : KotlinMockitoHelper() {
         val productDto = getProductDto(idFirmware = 1)
         Mockito.`when`(firmwareCacheService.getFirmware(productDto.idFirmware ?: 0)).thenReturn(getFirmware())
         Mockito.`when`(productDao.getReferenceById(0)).thenReturn(getProduct(idFirmware = 1, batteryLevel = 75))
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(true)
+        Mockito.`when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(true)
 
         //Act
         dataType2DfuPacketDataIdService.treat(productDto, payload)
@@ -69,6 +71,7 @@ class DataType2DfuReadyStatusIdleServiceTest : KotlinMockitoHelper() {
         Mockito.verify(dfuDataTopicService, Mockito.times(1)).sendStartOfTransmission(any(ProductDto::class.java), eq(65535), anyMap())
         Mockito.verify(dataTypeService, Mockito.times(1)).sendPacket(any(ProductDto::class.java), eq(1), anyMap(), eq(true))
         Mockito.verify(otauTrackingService, Mockito.times(1)).start(any(Product::class.java), anyMap())
+        Mockito.verify(otauTrackingService, Mockito.times(1)).isOtauSlotAvailable(anyMap())
     }
 
     @Test
@@ -81,8 +84,8 @@ class DataType2DfuReadyStatusIdleServiceTest : KotlinMockitoHelper() {
             0x00, //Process step IDLE
         )
         Mockito.`when`(productDao.getReferenceById(0)).thenReturn(getProduct(batteryLevel = 10))
-        val product = getProductDto()
-        Mockito.`when`(properties.minBatteryLvlOtau).thenReturn(50)
+        val product = getProductDto(batteryLevel = 10)
+        Mockito.`when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(false)
 
         //Act
         dataType2DfuPacketDataIdService.treat(product, payload)
@@ -90,6 +93,30 @@ class DataType2DfuReadyStatusIdleServiceTest : KotlinMockitoHelper() {
         //Assert
         Mockito.verify(dataTypeService, Mockito.times(1)).sendEndOfTransmissionIfNotEligibleToATargetVersion(any(ProductDto::class.java), anyMap())
         Mockito.verify(firmwareCacheService, Mockito.times(0)).getFirmware(anyLong())
+        Mockito.verify(dfuDataTopicService, Mockito.times(0)).sendStartOfTransmission(any(ProductDto::class.java), eq(65535), anyMap())
+        Mockito.verify(dataTypeService, Mockito.times(0)).sendPacket(any(ProductDto::class.java), eq(1), anyMap(), eq(true))
+        Mockito.verify(otauTrackingService, Mockito.times(0)).start(any(Product::class.java), anyMap())
+    }
+
+    @Test
+    fun `threat() IDLE #0 without slot should not send 'Start of Transmission'`() {
+        //Arrange
+        val payload = byteArrayOf(
+            0x02,
+            0x00,
+            0x00,
+            0x00,
+        )
+        val productDto = getProductDto(idFirmware = 1)
+        Mockito.`when`(firmwareCacheService.getFirmware(productDto.idFirmware ?: 0)).thenReturn(getFirmware())
+        Mockito.`when`(productDao.getReferenceById(0)).thenReturn(getProduct(idFirmware = 1, batteryLevel = 75))
+        Mockito.`when`(otauTrackingService.isOtauSlotAvailable(anyMap())).thenReturn(false)
+        Mockito.`when`(dataTypeService.isBatteryLevelSufficient(any(Short::class.javaObjectType), anyMap())).thenReturn(true)
+
+        //Act
+        dataType2DfuPacketDataIdService.treat(productDto, payload)
+
+        //Assert
         Mockito.verify(dfuDataTopicService, Mockito.times(0)).sendStartOfTransmission(any(ProductDto::class.java), eq(65535), anyMap())
         Mockito.verify(dataTypeService, Mockito.times(0)).sendPacket(any(ProductDto::class.java), eq(1), anyMap(), eq(true))
         Mockito.verify(otauTrackingService, Mockito.times(0)).start(any(Product::class.java), anyMap())


### PR DESCRIPTION
## Summary
- centralize slot availability logging in `OtauTrackingService.isOtauSlotAvailable`
- guard DFU continuation with slot availability check in `DataType2DfuPacketDataIdService`
- drop redundant slot logs from services now that tracking service handles them
- optimize `cleanupAndReturnNumberOfActiveOtau` with count and find queries to avoid scanning the entire table
- evaluate battery level from `ProductDto` in `startOtau`, avoiding an early database lookup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM fr.velco.back.framework:velco-back-framework-parent:pom:2.19.0; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b05e65d57c8325b84d175dee0d34a4